### PR TITLE
Fix hyperlink for upcoming event XP2018

### DIFF
--- a/public_html/events.html
+++ b/public_html/events.html
@@ -51,7 +51,7 @@
 
 
 <dl class="event-list">
-  <p><dt><a href="http://www.agileday.it">XP2018</a>&nbsp;<span class="location">Porto, Portugal</span>&nbsp;<span class="date">May 21-25, 2018</span></dt>
+  <p><dt><a href="https://www.agilealliance.org/xp2018">XP2018</a>&nbsp;<span class="location">Porto, Portugal</span>&nbsp;<span class="date">May 21-25, 2018</span></dt>
       
       
       <dd class="precis">


### PR DESCRIPTION
There appears to be a copy & paste error on the Events page: the hyperlink for the upcoming event XP2018 in Porto incorrectly points to http://www.agileday.it. This PR corrects the link to https://www.agilealliance.org/xp2018.